### PR TITLE
Use the native error pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.13
 
 require (
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
-	github.com/pkg/errors v0.8.1
 	gopkg.in/errgo.v1 v1.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/mongodb-labs/pcgc
 
 go 1.13
 
-require (
-	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
-	gopkg.in/errgo.v1 v1.0.1
-)
+require github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,2 @@
 github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a h1:KFHLI4QGttB0i7M3qOkAo8Zn/GSsxwwCnInFqBaYtkM=
 github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UAuEPckrDorYZdtlCu2ySOLuPB5W4rhIkmmc/XbI=
-github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
-github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
-github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
-github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-gopkg.in/errgo.v1 v1.0.1 h1:oQFRXzZ7CkBGdm1XZm/EbQYaYNNEElNBOd09M6cqNso=
-gopkg.in/errgo.v1 v1.0.1/go.mod h1:3NjfXwocQRYAPTq4/fzX+CwUhPRcR/azYRhj8G+LqMo=

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,5 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 gopkg.in/errgo.v1 v1.0.1 h1:oQFRXzZ7CkBGdm1XZm/EbQYaYNNEElNBOd09M6cqNso=
 gopkg.in/errgo.v1 v1.0.1/go.mod h1:3NjfXwocQRYAPTq4/fzX+CwUhPRcR/azYRhj8G+LqMo=

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -24,7 +24,6 @@ package httpclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mongodb-labs/pcgc/pkg/useful"
 	"gopkg.in/errgo.v1"
 	"io"
 	"net"
@@ -33,6 +32,7 @@ import (
 	"strings"
 
 	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
+	"github.com/mongodb-labs/pcgc/pkg/useful"
 )
 
 const (

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -24,12 +24,13 @@ package httpclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
-	"github.com/mongodb-labs/pcgc/pkg/useful"
 	"io"
 	"net"
 	"net/http"
 	"runtime"
+
+	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
+	"github.com/mongodb-labs/pcgc/pkg/useful"
 )
 
 const (

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -24,15 +24,12 @@ package httpclient
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/errgo.v1"
+	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
+	"github.com/mongodb-labs/pcgc/pkg/useful"
 	"io"
 	"net"
 	"net/http"
 	"runtime"
-	"strings"
-
-	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
-	"github.com/mongodb-labs/pcgc/pkg/useful"
 )
 
 const (
@@ -241,12 +238,7 @@ func validateStatusCode(r *HTTPResponse, expectedStatuses []int, verb string, ur
 	useful.PanicOnUnrecoverableError(err)
 
 	// otherwise augment the error and return false
-	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("failed to execute %s request to %s\n", verb, url))
-	sb.WriteString(fmt.Sprintf("status code: %d\n", r.Response.StatusCode))
-	sb.WriteString(fmt.Sprintf("response: %s\n", r.Response.Status))
-	sb.WriteString(fmt.Sprintf("details: %s\n", errorDetails))
-	r.Err = errgo.Notef(r.Err, sb.String())
+	r.Err = fmt.Errorf("failed to execute %s request to %s\n status code: %d\n response: %s\n details: %s\n %w", verb, url, r.Response.StatusCode, r.Response.Status, errorDetails, r.Err)
 
 	return false
 }

--- a/pkg/opsmanager/api_create_agent_api_key.go
+++ b/pkg/opsmanager/api_create_agent_api_key.go
@@ -3,6 +3,7 @@ package opsmanager
 import (
 	"bytes"
 	"encoding/json"
+
 	"github.com/mongodb-labs/pcgc/pkg/httpclient"
 	"github.com/mongodb-labs/pcgc/pkg/useful"
 )

--- a/pkg/opsmanager/client.go
+++ b/pkg/opsmanager/client.go
@@ -43,11 +43,11 @@
 package opsmanager
 
 import (
+	"errors"
 	"io"
 
 	"github.com/mongodb-labs/pcgc/pkg/httpclient"
 	"github.com/mongodb-labs/pcgc/pkg/useful"
-	"github.com/pkg/errors"
 )
 
 type opsManagerClient struct {


### PR DESCRIPTION
github.com/pkg/errors v0.8.1 is no longer supported and go offers a native implementation for our use case