### PR TITLE
Test simplifications

### DIFF
--- a/cloudmanager/automation_config.go
+++ b/cloudmanager/automation_config.go
@@ -105,17 +105,17 @@ type SSL struct {
 
 // Auth authentication config
 type Auth struct {
-	AuthoritativeSet         bool                     `json:"authoritativeSet"`
 	AutoAuthMechanism        string                   `json:"autoAuthMechanism"`
 	AutoUser                 string                   `json:"autoUser,omitempty"`
 	AutoPwd                  string                   `json:"autoPwd,omitempty"`
 	DeploymentAuthMechanisms []string                 `json:"deploymentAuthMechanisms"`
-	Disabled                 bool                     `json:"disabled"`
 	Key                      string                   `json:"key,omitempty"`
 	Keyfile                  string                   `json:"keyfile,omitempty"`
 	KeyfileWindows           string                   `json:"keyfileWindows,omitempty"`
 	UsersDeleted             []interface{}            `json:"usersDeleted"`
 	UsersWanted              []map[string]interface{} `json:"usersWanted"`
+	AuthoritativeSet         bool                     `json:"authoritativeSet"`
+	Disabled                 bool                     `json:"disabled"`
 }
 
 // Member configs
@@ -194,15 +194,15 @@ type LogRotate struct {
 type Process struct {
 	Args26                      Args26     `json:"args2_6"`
 	AuthSchemaVersion           int        `json:"authSchemaVersion,omitempty"`
+	LastGoalVersionAchieved     int        `json:"lastGoalVersionAchieved,omitempty"`
 	Name                        string     `json:"name,omitempty"`
 	Cluster                     string     `json:"cluster,omitempty"`
-	Disabled                    bool       `json:"disabled,omitempty"`
 	FeatureCompatibilityVersion string     `json:"featureCompatibilityVersion,omitempty"`
 	Hostname                    string     `json:"hostname,omitempty"`
-	LastGoalVersionAchieved     int        `json:"lastGoalVersionAchieved,omitempty"`
 	LogRotate                   *LogRotate `json:"logRotate,omitempty"`
-	ManualMode                  bool       `json:"manualMode,omitempty"`
 	Plan                        []string   `json:"plan,omitempty"`
 	ProcessType                 string     `json:"processType,omitempty"`
 	Version                     string     `json:"version,omitempty"`
+	Disabled                    bool       `json:"disabled,omitempty"`
+	ManualMode                  bool       `json:"manualMode,omitempty"`
 }

--- a/cloudmanager/automation_config_test.go
+++ b/cloudmanager/automation_config_test.go
@@ -18,8 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 const jsonBlob = `{
@@ -184,7 +185,7 @@ func TestAutomationConfig_Get(t *testing.T) {
 
 	config, _, err := client.AutomationConfig.Get(ctx, projectID)
 	if err != nil {
-		t.Errorf("AutomationConfig.Get returned error: %v", err)
+		t.Fatalf("AutomationConfig.Get returned error: %v", err)
 	}
 
 	expected := &AutomationConfig{
@@ -328,9 +329,8 @@ func TestAutomationConfig_Get(t *testing.T) {
 		},
 		Version: 1,
 	}
-
-	if !reflect.DeepEqual(config, expected) {
-		t.Errorf("AutomationConfig.Get\n got=%#v\nwant=%#v", config, expected)
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -493,6 +493,6 @@ func TestAutomationConfig_Update(t *testing.T) {
 
 	_, err := client.AutomationConfig.Update(ctx, projectID, updateRequest)
 	if err != nil {
-		t.Errorf("AutomationConfig.Update returned error: %v", err)
+		t.Fatalf("AutomationConfig.Update returned error: %v", err)
 	}
 }

--- a/cloudmanager/projects.go
+++ b/cloudmanager/projects.go
@@ -28,7 +28,7 @@ const (
 
 // ProjectsService is an interface for interfacing with the Projects
 // endpoints of the MongoDB Atlas API.
-// See more: https://docs.atlas.mongodb.com/reference/api/projects/
+// See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/
 type ProjectsService interface {
 	GetAllProjects(context.Context) (*Projects, *atlas.Response, error)
 	GetOneProject(context.Context, string) (*Project, *atlas.Response, error)
@@ -37,8 +37,8 @@ type ProjectsService interface {
 	Delete(context.Context, string) (*atlas.Response, error)
 }
 
-//ProjectsServiceOp handles communication with the Projects related methos of the
-//MongoDB Atlas API
+// ProjectsServiceOp handles communication with the Projects related methos of the
+// MongoDB Cloud Manager API
 type ProjectsServiceOp struct {
 	client *Client
 }
@@ -78,8 +78,8 @@ type Projects struct {
 	TotalCount int           `json:"totalCount"`
 }
 
-//GetAllProjects gets all project.
-//See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-all-groups-for-current-user/
+// GetAllProjects gets all project.
+// See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-all-groups-for-current-user/
 func (s *ProjectsServiceOp) GetAllProjects(ctx context.Context) (*Projects, *atlas.Response, error) {
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, projectBasePath, nil)
@@ -100,8 +100,8 @@ func (s *ProjectsServiceOp) GetAllProjects(ctx context.Context) (*Projects, *atl
 	return root, resp, nil
 }
 
-//GetOneProject gets a single project.
-//See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-one-group-by-id/
+// GetOneProject gets a single project.
+// See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-one-group-by-id/
 func (s *ProjectsServiceOp) GetOneProject(ctx context.Context, projectID string) (*Project, *atlas.Response, error) {
 	if projectID == "" {
 		return nil, nil, atlas.NewArgError("projectID", "must be set")
@@ -123,8 +123,8 @@ func (s *ProjectsServiceOp) GetOneProject(ctx context.Context, projectID string)
 	return root, resp, err
 }
 
-//GetOneProjectByName gets a single project by its name.
-//See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-one-group-by-name/
+// GetOneProjectByName gets a single project by its name.
+// See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-one-group-by-name/
 func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName string) (*Project, *atlas.Response, error) {
 	if projectName == "" {
 		return nil, nil, atlas.NewArgError("projectName", "must be set")
@@ -146,8 +146,8 @@ func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName
 	return root, resp, err
 }
 
-//Create creates a project.
-//See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/create-one-group/
+// Create creates a project.
+// See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/create-one-group/
 func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project) (*Project, *atlas.Response, error) {
 	if createRequest == nil {
 		return nil, nil, atlas.NewArgError("createRequest", "cannot be nil")
@@ -167,7 +167,7 @@ func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project) 
 	return root, resp, err
 }
 
-//Delete deletes a project.
+// Delete deletes a project.
 // See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/delete-one-group/
 func (s *ProjectsServiceOp) Delete(ctx context.Context, projectID string) (*atlas.Response, error) {
 	if projectID == "" {

--- a/cloudmanager/projects.go
+++ b/cloudmanager/projects.go
@@ -27,7 +27,7 @@ const (
 )
 
 // ProjectsService is an interface for interfacing with the Projects
-// endpoints of the MongoDB Atlas API.
+// endpoints of the MongoDB Cloud Manager API.
 // See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/
 type ProjectsService interface {
 	GetAllProjects(context.Context) (*Projects, *atlas.Response, error)
@@ -37,7 +37,7 @@ type ProjectsService interface {
 	Delete(context.Context, string) (*atlas.Response, error)
 }
 
-// ProjectsServiceOp handles communication with the Projects related methos of the
+// ProjectsServiceOp handles communication with the Projects related methods of the
 // MongoDB Cloud Manager API
 type ProjectsServiceOp struct {
 	client *Client
@@ -78,7 +78,7 @@ type Projects struct {
 	TotalCount int           `json:"totalCount"`
 }
 
-// GetAllProjects gets all project.
+// GetAllProjects gets all projects.
 // See more: https://docs.cloudmanager.mongodb.com/reference/api/groups/get-all-groups-for-current-user/
 func (s *ProjectsServiceOp) GetAllProjects(ctx context.Context) (*Projects, *atlas.Response, error) {
 

--- a/cloudmanager/projects_test.go
+++ b/cloudmanager/projects_test.go
@@ -17,7 +17,6 @@ package cloudmanager
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -88,7 +87,7 @@ func TestProject_GetAllProjects(t *testing.T) {
 
 	projects, _, err := client.Projects.GetAllProjects(ctx)
 	if err != nil {
-		t.Errorf("Projects.GetAllProjects returned error: %v", err)
+		t.Fatalf("Projects.GetAllProjects returned error: %v", err)
 	}
 
 	expected := &Projects{
@@ -155,8 +154,8 @@ func TestProject_GetAllProjects(t *testing.T) {
 		TotalCount: 2,
 	}
 
-	if !reflect.DeepEqual(projects, expected) {
-		t.Errorf("Projects.GetAllProjects\n got=%#v\nwant=%#v", projects, expected)
+	if diff := deep.Equal(projects, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -196,7 +195,7 @@ func TestProject_GetOneProject(t *testing.T) {
 
 	projectResponse, _, err := client.Projects.GetOneProject(ctx, projectID)
 	if err != nil {
-		t.Errorf("Projects.GetOneProject returned error: %v", err)
+		t.Fatalf("Projects.GetOneProject returned error: %v", err)
 	}
 
 	expected := &Project{
@@ -226,8 +225,8 @@ func TestProject_GetOneProject(t *testing.T) {
 		Tags:             []*string{},
 	}
 
-	if !reflect.DeepEqual(projectResponse, expected) {
-		t.Errorf("Projects.GetOneProject\n got=%#v\nwant=%#v", projectResponse, expected)
+	if diff := deep.Equal(projectResponse, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -267,7 +266,7 @@ func TestProject_GetOneProjectByName(t *testing.T) {
 
 	projectResponse, _, err := client.Projects.GetOneProjectByName(ctx, projectName)
 	if err != nil {
-		t.Errorf("Projects.GetOneProject returned error: %v", err)
+		t.Fatalf("Projects.GetOneProject returned error: %v", err)
 	}
 
 	expected := &Project{
@@ -299,9 +298,6 @@ func TestProject_GetOneProjectByName(t *testing.T) {
 
 	if diff := deep.Equal(projectResponse, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(projectResponse, expected) {
-		t.Errorf("Projects.GetOneProject\n got=%#v\nwant=%#v", projectResponse, expected)
 	}
 }
 
@@ -343,7 +339,7 @@ func TestProject_Create(t *testing.T) {
 
 	project, _, err := client.Projects.Create(ctx, createRequest)
 	if err != nil {
-		t.Errorf("Projects.Create returned error: %v", err)
+		t.Fatalf("Projects.Create returned error: %v", err)
 	}
 
 	expected := &Project{
@@ -376,9 +372,6 @@ func TestProject_Create(t *testing.T) {
 	if diff := deep.Equal(project, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(project, expected) {
-		t.Errorf("DatabaseUsers.Get\n got=%#v\nwant=%#v", project, expected)
-	}
 }
 
 func TestProject_Delete(t *testing.T) {
@@ -393,6 +386,6 @@ func TestProject_Delete(t *testing.T) {
 
 	_, err := client.Projects.Delete(ctx, projectID)
 	if err != nil {
-		t.Errorf("Projects.Delete returned error: %v", err)
+		t.Fatalf("Projects.Delete returned error: %v", err)
 	}
 }


### PR DESCRIPTION
This just looks at standardizing our use of `deep.Equal` instead of reflects methods
Also changes some errors to fatal to prevent future execution